### PR TITLE
Language Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +47,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "filetime"
@@ -286,6 +305,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "radium"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,8 +357,21 @@ dependencies = [
  "hotwatch",
  "lazy_static",
  "libc",
+ "log",
  "nom",
  "nom_locate",
+ "simplelog",
+]
+
+[[package]]
+name = "simplelog"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bc0ffd69814a9b251d43afcabf96dad1b29f5028378056257be9e3fecc9f720"
+dependencies = [
+ "chrono",
+ "log",
+ "termcolor",
 ]
 
 [[package]]
@@ -342,6 +393,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +428,12 @@ dependencies = [
  "winapi 0.3.9",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,10 +37,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "filetime"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
 name = "funty"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
+
+[[package]]
+name = "hotwatch"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61ee702e77f237b41761361a82e5c4bf6277dbb4bc8b6b7d745cb249cc82b31"
+dependencies = [
+ "log",
+ "notify",
+]
+
+[[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4563555856585ab3180a5bf0b2f9f8d301a728462afffc8195b3f5394229c55"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
@@ -50,7 +164,7 @@ checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
 ]
@@ -62,10 +176,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
+name = "log"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "mio"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "nom"
@@ -91,10 +268,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "radium"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "ryu"
@@ -103,13 +304,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "sanny_builder_core"
 version = "0.1.1"
 dependencies = [
+ "hotwatch",
+ "lazy_static",
  "libc",
  "nom",
  "nom_locate",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "static_assertions"
@@ -128,6 +346,70 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ nom = "6.0.1"
 nom_locate = "3.0.0"
 hotwatch = "0.4.5"
 lazy_static = "1.4.0"
+log = { version = "0.4.11", features = ["release_max_level_off"] }
+simplelog = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ crate-type = ["rlib", "cdylib"]
 libc = "0.2.79"
 nom = "6.0.1"
 nom_locate = "3.0.0"
+hotwatch = "0.4.5"
+lazy_static = "1.4.0"

--- a/src/common_ffi.rs
+++ b/src/common_ffi.rs
@@ -4,7 +4,11 @@ use std::ffi::{CStr, CString};
 pub type PChar = *const c_char;
 
 pub fn pchar_to_string<'a>(s: PChar) -> Option<String> {
-    Some(String::from(pchar_to_str(s)?))
+    if s.is_null() {
+        None
+    } else {
+        unsafe { Some(String::from(CStr::from_ptr(s).to_string_lossy())) }
+    }
 }
 
 pub fn pchar_to_str<'a>(s: PChar) -> Option<&'a str> {

--- a/src/common_ffi.rs
+++ b/src/common_ffi.rs
@@ -8,7 +8,11 @@ pub fn pchar_to_string<'a>(s: PChar) -> Option<String> {
 }
 
 pub fn pchar_to_str<'a>(s: PChar) -> Option<&'a str> {
-    unsafe { Some(CStr::from_ptr(s).to_str().ok()?) }
+    if s.is_null() {
+        None
+    } else {
+        unsafe { Some(CStr::from_ptr(s).to_str().ok()?) }
+    }
 }
 
 #[no_mangle]

--- a/src/dictionary/config.rs
+++ b/src/dictionary/config.rs
@@ -1,0 +1,68 @@
+use super::ffi::{CaseFormat, Duplicates};
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub duplicates: Duplicates,
+    pub case_format: CaseFormat,
+    pub comments: String,
+    pub delimiters: String,
+    pub strip_whitespace: bool,
+    pub hex_keys: bool,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ConfigBuilder(Config);
+
+impl ConfigBuilder {
+    pub fn new() -> ConfigBuilder {
+        ConfigBuilder(Config::default())
+    }
+
+    pub fn set_duplicates<'a>(&'a mut self, duplicates: Duplicates) -> &'a mut ConfigBuilder {
+        self.0.duplicates = duplicates;
+        self
+    }
+
+    pub fn set_case_format<'a>(&'a mut self, case_format: CaseFormat) -> &'a mut ConfigBuilder {
+        self.0.case_format = case_format;
+        self
+    }
+
+    pub fn set_comments<'a>(&'a mut self, comments: String) -> &'a mut ConfigBuilder {
+        self.0.comments = comments;
+        self
+    }
+
+    pub fn set_delimiters<'a>(&'a mut self, delimiters: String) -> &'a mut ConfigBuilder {
+        self.0.delimiters = delimiters;
+        self
+    }
+
+    pub fn set_strip_whitespace<'a>(&'a mut self, strip_whitespace: bool) -> &'a mut ConfigBuilder {
+        self.0.strip_whitespace = strip_whitespace;
+        self
+    }
+
+    pub fn set_hex_keys<'a>(&'a mut self, hex_keys: bool) -> &'a mut ConfigBuilder {
+        self.0.hex_keys = hex_keys;
+        self
+    }
+
+    pub fn build(&mut self) -> Config {
+        self.0.clone()
+    }
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            duplicates: Duplicates::Replace,
+            case_format: CaseFormat::NoFormat,
+            comments: String::from(";"),
+            delimiters: String::from("=,"),
+            strip_whitespace: true,
+            hex_keys: false,
+        }
+    }
+}

--- a/src/dictionary/mod.rs
+++ b/src/dictionary/mod.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod dictionary_num_by_str;
 pub mod dictionary_str_by_num;
 pub mod dictionary_str_by_str;

--- a/src/language_service/ffi.rs
+++ b/src/language_service/ffi.rs
@@ -25,6 +25,7 @@ pub struct DocumentInfo {
     pub is_active: bool,
 }
 
+#[derive(Clone)]
 pub struct SymbolInfoMap {
     pub file_name: Option<String>,
     pub line_number: u32,

--- a/src/language_service/ffi.rs
+++ b/src/language_service/ffi.rs
@@ -57,9 +57,10 @@ pub unsafe extern "C" fn language_service_client_connect(
     server: *mut LanguageServer,
     file_name: PChar,
     handle: EditorHandle,
+    static_constants_file: PChar,
 ) -> bool {
     boolclosure! {{
-        server.as_mut()?.connect(pchar_to_str(file_name)?, handle);
+        server.as_mut()?.connect(pchar_to_str(file_name)?, handle, pchar_to_str(static_constants_file)?);
         Some(())
     }}
 }

--- a/src/language_service/ffi.rs
+++ b/src/language_service/ffi.rs
@@ -9,12 +9,20 @@ pub enum SymbolType {
     Number = 0,
     String = 1,
     Var = 2,
+    Label = 3,
+    ModelName = 4,
 }
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct SymbolInfo {
     pub line_number: u32,
     pub _type: SymbolType,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ServerInfo {
+    pub status: i32,
 }
 
 pub struct SymbolInfoMap {
@@ -37,25 +45,24 @@ pub unsafe extern "C" fn language_service_free(server: *mut LanguageServer) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn language_service_client_file_open(
+pub unsafe extern "C" fn language_service_client_connect(
     server: *mut LanguageServer,
     file_name: PChar,
     handle: EditorHandle,
 ) -> bool {
     boolclosure! {{
-        server.as_mut()?.open(pchar_to_str(file_name)?, handle);
+        server.as_mut()?.connect(pchar_to_str(file_name)?, handle);
         Some(())
     }}
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn language_service_client_file_close(
+pub unsafe extern "C" fn language_service_client_disconnect(
     server: *mut LanguageServer,
-    file_name: PChar,
     handle: EditorHandle,
 ) -> bool {
     boolclosure! {{
-        server.as_mut()?.close(pchar_to_str(file_name)?, handle);
+        server.as_mut()?.disconnect(handle);
         Some(())
     }}
 }
@@ -73,6 +80,19 @@ pub unsafe extern "C" fn language_service_find(
         let s = server.find(pchar_to_str(symbol)?, editor, pchar_to_str(file_name)?)?;
         out_value.as_mut()?._type = s._type;
         out_value.as_mut()?.line_number = s.line_number;
+        Some(())
+    }}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn language_service_info(
+    server: *mut LanguageServer,
+    out_value: *mut ServerInfo,
+) -> bool {
+    boolclosure! {{
+        let _server = server.as_mut()?;
+        let info = out_value.as_mut()?;
+        info.status = 1;
         Some(())
     }}
 }

--- a/src/language_service/ffi.rs
+++ b/src/language_service/ffi.rs
@@ -1,0 +1,78 @@
+use crate::{
+    common_ffi::{pchar_to_str, ptr_free, ptr_new, PChar},
+    language_service::server::LanguageServer,
+};
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub enum SymbolType {
+    Number = 0,
+    String = 1,
+    Var = 2,
+}
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SymbolInfo {
+    pub line_number: u32,
+    pub _type: SymbolType,
+}
+
+pub struct SymbolInfoMap {
+    pub file_name: String,
+    pub line_number: u32,
+    pub _type: SymbolType,
+}
+
+pub type EditorHandle = u32;
+pub type NotifyCallback = extern "C" fn(EditorHandle);
+
+#[no_mangle]
+pub extern "C" fn language_service_new(cb: NotifyCallback) -> *mut LanguageServer {
+    ptr_new(LanguageServer::new(cb))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn language_service_free(server: *mut LanguageServer) {
+    ptr_free(server);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn language_service_client_file_open(
+    server: *mut LanguageServer,
+    file_name: PChar,
+    handle: EditorHandle,
+) -> bool {
+    boolclosure! {{
+        server.as_mut()?.open(pchar_to_str(file_name)?, handle);
+        Some(())
+    }}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn language_service_client_file_close(
+    server: *mut LanguageServer,
+    file_name: PChar,
+    handle: EditorHandle,
+) -> bool {
+    boolclosure! {{
+        server.as_mut()?.close(pchar_to_str(file_name)?, handle);
+        Some(())
+    }}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn language_service_find(
+    server: *mut LanguageServer,
+    symbol: PChar,
+    editor: EditorHandle,
+    file_name: PChar,
+    out_value: *mut SymbolInfo,
+) -> bool {
+    boolclosure! {{
+        let server = server.as_mut()?;
+        let s = server.find(pchar_to_str(symbol)?, editor, pchar_to_str(file_name)?)?;
+        out_value.as_mut()?._type = s._type;
+        out_value.as_mut()?.line_number = s.line_number;
+        Some(())
+    }}
+}

--- a/src/language_service/ffi.rs
+++ b/src/language_service/ffi.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common_ffi::{pchar_to_str, ptr_free, ptr_new, PChar},
+    common_ffi::{pchar_to_str, pchar_to_string, ptr_free, ptr_new, PChar},
     language_service::server::LanguageServer,
 };
 
@@ -24,20 +24,31 @@ pub struct DocumentInfo {
 }
 
 pub struct SymbolInfoMap {
-    pub file_name: String,
+    pub file_name: Option<String>,
     pub line_number: u32,
     pub _type: SymbolType,
 }
+#[repr(C)]
 #[derive(Clone, Copy)]
+#[allow(dead_code)]
 pub enum Status {
+    Disabled = 0,
     Ready = 1,
     Scanning = 2,
+    PendingUpdate = 3,
+    Unknown = 254,
+    Error = 255,
+}
+
+#[derive(Debug, Clone)]
+pub enum Source {
+    Memory,
+    File(String),
 }
 
 pub type EditorHandle = u32;
 pub type NotifyCallback = extern "C" fn(EditorHandle);
-
-pub type StatusChangeCallback = extern "C" fn(EditorHandle, i32);
+pub type StatusChangeCallback = extern "C" fn(EditorHandle, Status);
 
 #[no_mangle]
 pub extern "C" fn language_service_new(
@@ -53,15 +64,38 @@ pub unsafe extern "C" fn language_service_free(server: *mut LanguageServer) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn language_service_client_connect(
+pub unsafe extern "C" fn language_service_client_connect_with_file(
     server: *mut LanguageServer,
     file_name: PChar,
     handle: EditorHandle,
     static_constants_file: PChar,
 ) -> bool {
     boolclosure! {{
-        server.as_mut()?.connect(pchar_to_str(file_name)?, handle, pchar_to_str(static_constants_file)?);
+        server.as_mut()?.connect(Source::File(pchar_to_string(file_name)?), handle, pchar_to_str(static_constants_file)?);
         Some(())
+    }}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn language_service_client_connect_in_memory(
+    server: *mut LanguageServer,
+    handle: EditorHandle,
+    static_constants_file: PChar,
+) -> bool {
+    boolclosure! {{
+        server.as_mut()?.connect(Source::Memory, handle, pchar_to_str(static_constants_file)?);
+        Some(())
+    }}
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn language_service_client_notify_on_change(
+    server: *mut LanguageServer,
+    handle: EditorHandle,
+    text: PChar,
+) -> bool {
+    boolclosure! {{
+        server.as_mut()?.message_queue.send((handle, pchar_to_string(text)?)).ok()
     }}
 }
 
@@ -81,12 +115,11 @@ pub unsafe extern "C" fn language_service_find(
     server: *mut LanguageServer,
     symbol: PChar,
     handle: EditorHandle,
-    file_name: PChar,
     out_value: *mut SymbolInfo,
 ) -> bool {
     boolclosure! {{
         let server = server.as_mut()?;
-        let s = server.find(pchar_to_str(symbol)?, handle, pchar_to_str(file_name)?)?;
+        let s = server.find(pchar_to_str(symbol)?, handle)?;
         out_value.as_mut()?._type = s._type;
         out_value.as_mut()?.line_number = s.line_number;
         Some(())

--- a/src/language_service/mod.rs
+++ b/src/language_service/mod.rs
@@ -1,0 +1,5 @@
+mod ffi;
+mod scanner;
+mod server;
+mod symbol_table;
+mod watcher;

--- a/src/language_service/scanner.rs
+++ b/src/language_service/scanner.rs
@@ -64,10 +64,10 @@ pub fn document_tree<'a>(file_name: &'a str, dict: &DictNumByStr) -> Option<Vec<
 }
 
 pub fn find_constants<'a>(
-    file_name: String,
+    file_name: &String,
     dict: &DictNumByStr,
 ) -> Option<Vec<(String, SymbolInfoMap)>> {
-    let content = fs::read_to_string(&file_name).ok()?;
+    let content = fs::read_to_string(file_name).ok()?;
     let mut lines = content.lines().enumerate();
     let mut res = vec![];
     let mut inside_const = false;

--- a/src/language_service/scanner.rs
+++ b/src/language_service/scanner.rs
@@ -166,6 +166,9 @@ pub fn get_type(value: &str) -> Option<SymbolType> {
     if let Some(_) = value.parse::<f32>().ok() {
         return Some(SymbolType::Number);
     }
+    if value.starts_with("0x") || value.starts_with("-0x") {
+        return Some(SymbolType::Number);
+    }
     return None;
 }
 

--- a/src/language_service/scanner.rs
+++ b/src/language_service/scanner.rs
@@ -151,6 +151,7 @@ pub fn find_constants<'a>(
                                 line_number: line_number as u32,
                                 _type: SymbolType::Var,
                                 file_name: file_name.clone(),
+                                value: None,
                             },
                         ))
                     }
@@ -170,6 +171,7 @@ pub fn find_constants<'a>(
                                     line_number: line_number as u32,
                                     _type,
                                     file_name: file_name.clone(),
+                                    value: Some(String::from(value)),
                                 },
                             ))
                         }

--- a/src/language_service/scanner.rs
+++ b/src/language_service/scanner.rs
@@ -1,0 +1,148 @@
+use super::ffi::{SymbolInfoMap, SymbolType};
+use crate::dictionary::dictionary_num_by_str::DictNumByStr;
+use std::fs;
+use std::path::Path;
+
+const TOKEN_INCLUDE: i32 = 103;
+const TOKEN_CONST: i32 = 65;
+const TOKEN_END: i32 = 255;
+const TOKEN_INT: i32 = 1;
+const TOKEN_FLOAT: i32 = 2;
+const TOKEN_STRING: i32 = 3;
+const TOKEN_LONGSTRING: i32 = 4;
+const TOKEN_HANDLE: i32 = 5;
+const TOKEN_BOOL: i32 = 6;
+
+fn document_tree_walk<'a>(file_name: String, dict: &DictNumByStr) -> Option<Vec<String>> {
+    let content = fs::read_to_string(&file_name).ok()?;
+    let mut files = content
+        .lines()
+        .filter_map(|x| {
+            // todo: use nom parser
+            let mut words = x.split_ascii_whitespace();
+            let first = words.next()?.to_ascii_lowercase();
+
+            if let Some(token) = dict.map.get(&first) {
+                if token == &TOKEN_INCLUDE {
+                    let mut include_path = words.collect::<String>();
+
+                    if include_path.ends_with('}') {
+                        include_path.pop();
+                    }
+
+                    return Some(document_tree_walk(
+                        resolve_path(include_path, &file_name)?,
+                        dict,
+                    )?);
+                }
+            }
+            None
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+
+    files.push(file_name);
+    Some(files)
+}
+
+fn resolve_path(p: String, parent_file: &String) -> Option<String> {
+    let path = Path::new(&p);
+
+    if path.is_absolute() {
+        return Some(p);
+    }
+
+    let dir_name = Path::new(&parent_file).parent()?;
+    let abs_name = dir_name.join(path);
+
+    return Some(String::from(abs_name.to_str()?));
+}
+
+pub fn document_tree<'a>(file_name: &'a str, dict: &DictNumByStr) -> Option<Vec<String>> {
+    Some(document_tree_walk(file_name.to_string(), dict)?)
+}
+
+pub fn find_constants<'a>(
+    file_name: String,
+    dict: &DictNumByStr,
+) -> Option<Vec<(String, SymbolInfoMap)>> {
+    let content = fs::read_to_string(&file_name).ok()?;
+    let mut lines = content.lines().enumerate();
+    let mut res = vec![];
+    let mut inside_const = false;
+    while let Some((line_number, mut line)) = lines.next() {
+        line = line.trim();
+        if line.is_empty() || line.starts_with("//") {
+            continue;
+        }
+        let mut words = line.split_ascii_whitespace();
+        let first = words.next().unwrap_or("");
+        match dict.map.get(first) {
+            Some(token) => match *token {
+                TOKEN_CONST => inside_const = true,
+                TOKEN_END if inside_const => inside_const = false,
+                TOKEN_INT | TOKEN_FLOAT | TOKEN_STRING | TOKEN_LONGSTRING | TOKEN_HANDLE
+                | TOKEN_BOOL => {
+                    // inline variable declaration
+                    let name = words.next().unwrap_or("");
+                    if !name.is_empty() {
+                        res.push((
+                            String::from(name),
+                            SymbolInfoMap {
+                                line_number: line_number as u32,
+                                _type: SymbolType::Var,
+                                file_name: file_name.clone(),
+                            },
+                        ))
+                    }
+                }
+                _ => {}
+            },
+            _ if inside_const => {
+                // todo: try nom parser
+                let mut tokens = line.split('=');
+
+                if let Some(mut name) = tokens.next() {
+                    if let Some(mut value) = tokens.next() {
+                        name = name.trim();
+                        value = value.trim();
+                        let mut _type = SymbolType::Number;
+                        if value.starts_with('$') || value.ends_with('@') {
+                            _type = SymbolType::Var
+                        } else if value.starts_with('"') || value.starts_with('\'') {
+                            _type = SymbolType::String
+                        } else if let Some(_) = value.parse::<f32>().ok() {
+                            _type = SymbolType::Number
+                        } else {
+                            continue;
+                        }
+                        res.push((
+                            String::from(name),
+                            SymbolInfoMap {
+                                line_number: line_number as u32,
+                                _type,
+                                file_name: file_name.clone(),
+                            },
+                        ))
+                    }
+                }
+            }
+            _ => {
+                // ignore other lines
+            }
+        }
+    }
+
+    Some(res)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test1() {
+        let p = resolve_path(String::from("2.txt"), &String::from("C:/dev/1.txt")).unwrap();
+        assert_eq!(p, String::from("C:/dev\\2.txt"));
+    }
+}

--- a/src/language_service/scanner.rs
+++ b/src/language_service/scanner.rs
@@ -3,6 +3,7 @@ use crate::dictionary::dictionary_num_by_str::DictNumByStr;
 use std::fs;
 use std::path::Path;
 
+// from compiler.ini
 const TOKEN_INCLUDE: i32 = 103;
 const TOKEN_CONST: i32 = 65;
 const TOKEN_END: i32 = 255;
@@ -111,6 +112,10 @@ pub fn find_constants<'a>(
                             _type = SymbolType::Var
                         } else if value.starts_with('"') || value.starts_with('\'') {
                             _type = SymbolType::String
+                        } else if value.starts_with('#') {
+                            _type = SymbolType::ModelName
+                        } else if value.starts_with('@') {
+                            _type = SymbolType::Label
                         } else if let Some(_) = value.parse::<f32>().ok() {
                             _type = SymbolType::Number
                         } else {

--- a/src/language_service/scanner.rs
+++ b/src/language_service/scanner.rs
@@ -171,7 +171,7 @@ pub fn find_constants<'a>(
                                     line_number: line_number as u32,
                                     _type,
                                     file_name: file_name.clone(),
-                                    value: Some(String::from(value)),
+                                    value: Some(String::from(value.trim())),
                                 },
                             ))
                         }

--- a/src/language_service/server.rs
+++ b/src/language_service/server.rs
@@ -128,6 +128,27 @@ impl LanguageServer {
         }
     }
 
+    pub fn filter_constants_by_name(
+        &self,
+        needle: &str,
+        handle: EditorHandle,
+    ) -> Option<Vec<(String, String)>> {
+        let st = SYMBOL_TABLES.lock().unwrap();
+        let table = st.get(&handle)?;
+        let needle = needle.to_ascii_lowercase();
+        Some(
+            table
+                .symbols
+                .iter()
+                .filter_map(|(name, map)| {
+                    name.to_ascii_lowercase()
+                        .starts_with(&needle)
+                        .then_some((name.clone(), map.value.clone()?.clone()))
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
     fn setup_message_queue(status_change: StatusChangeCallback) -> Sender<(EditorHandle, String)> {
         let (message_queue, receiver) = channel();
         thread::spawn(move || loop {

--- a/src/language_service/server.rs
+++ b/src/language_service/server.rs
@@ -220,6 +220,7 @@ impl LanguageServer {
                     let file_name1 = file_name.clone();
                     watcher.watch(file_name.as_str(), move |event| match event {
                         hotwatch::Event::Write(_) => {
+                            // todo: check if possible to use file name from event payload
                             LanguageServer::invalidate_file_cache(&file_name1);
                             LanguageServer::rescan(&file_name1, status_change)
                         }
@@ -238,18 +239,15 @@ impl LanguageServer {
         // invalidate cache for all files referencing this file
         // todo: change file cache to only store its own references and not children
         // then use cache.remove(file_name)
-        let drained = cache
+        let _drained = cache
             .drain_filter(|k, v| {
                 if k == file_name || v.contains(file_name) {
+                    log::debug!("Invalidating tree cache for file {}", k);
                     return true;
                 }
                 return false;
             })
             .collect::<Vec<_>>();
-
-        for (d, _) in drained {
-            log::debug!("Invalidated tree cache for file {}", d);
-        }
 
         CACHE_FILE_SYMBOLS
             .lock()

--- a/src/language_service/server.rs
+++ b/src/language_service/server.rs
@@ -86,18 +86,6 @@ impl LanguageServer {
         status_change(handle, Status::PendingScan);
     }
 
-    fn rescan(file_name: &String, status_change: StatusChangeCallback) {
-        log::debug!("File {} has changed", file_name);
-        let files = WATCHED_FILES.lock().unwrap();
-
-        if let Some(handles) = files.get(file_name.as_str()) {
-            log::debug!("Found {} dependent clients", handles.len());
-            for &handle in handles {
-                status_change(handle, Status::PendingScan)
-            }
-        }
-    }
-
     pub fn disconnect(&mut self, handle: EditorHandle) {
         log::debug!("Client {} disconnected", handle);
         SYMBOL_TABLES.lock().unwrap().remove(&handle);
@@ -210,6 +198,18 @@ impl LanguageServer {
                         }
                     });
                 }
+            }
+        }
+    }
+
+    fn rescan(file_name: &String, status_change: StatusChangeCallback) {
+        log::debug!("File {} has changed", file_name);
+        let files = WATCHED_FILES.lock().unwrap();
+
+        if let Some(handles) = files.get(file_name.as_str()) {
+            log::debug!("Found {} dependent clients", handles.len());
+            for &handle in handles {
+                status_change(handle, Status::PendingScan)
             }
         }
     }

--- a/src/language_service/server.rs
+++ b/src/language_service/server.rs
@@ -5,10 +5,7 @@ use super::{
     watcher::FileWatcher,
     {scanner, symbol_table::SymbolTable},
 };
-use crate::dictionary::{
-    dictionary_num_by_str::DictNumByStr,
-    ffi::{CaseFormat, Duplicates},
-};
+use crate::dictionary::{config, dictionary_num_by_str::DictNumByStr};
 use lazy_static::lazy_static;
 use std::{
     collections::{HashMap, HashSet},
@@ -29,14 +26,8 @@ lazy_static! {
     static ref WATCHED_FILES: Mutex<HashMap<String, HashSet<EditorHandle>>> =
         Mutex::new(HashMap::new());
     static ref SOURCE_MAP: Mutex<HashMap<EditorHandle, Source>> = Mutex::new(HashMap::new());
-    static ref RESERVED_WORDS: Mutex<DictNumByStr> = Mutex::new(DictNumByStr::new(
-        Duplicates::Replace,
-        CaseFormat::LowerCase,
-        String::from(";"),
-        String::from("=,"),
-        true,
-        false,
-    ));
+    static ref RESERVED_WORDS: Mutex<DictNumByStr> =
+        Mutex::new(DictNumByStr::new(config::Config::default()));
     static ref FILE_WATCHER: Mutex<FileWatcher> = Mutex::new(FileWatcher::new());
     static ref IMPLICIT_INCLUDES: Mutex<HashMap<EditorHandle, Vec<String>>> =
         Mutex::new(HashMap::new());

--- a/src/language_service/server.rs
+++ b/src/language_service/server.rs
@@ -1,0 +1,144 @@
+use super::{
+    ffi::{EditorHandle, NotifyCallback, SymbolInfo},
+    watcher::FileWatcher,
+    {scanner, symbol_table::SymbolTable},
+};
+use crate::dictionary::{
+    dictionary_num_by_str::DictNumByStr,
+    ffi::{CaseFormat, Duplicates},
+};
+use lazy_static::lazy_static;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Mutex,
+    thread,
+};
+
+lazy_static! {
+    static ref SYMBOL_TABLES: Mutex<HashMap<EditorHandle, SymbolTable>> =
+        Mutex::new(HashMap::new());
+    static ref WATCHED_FILES: Mutex<HashMap<String, HashSet<EditorHandle>>> =
+        Mutex::new(HashMap::new());
+    static ref RESERVED_WORDS: Mutex<DictNumByStr> = Mutex::new(DictNumByStr::new(
+        Duplicates::Replace,
+        CaseFormat::LowerCase,
+        String::from(";"),
+        String::from("=,"),
+        true,
+        false,
+    ));
+}
+
+pub struct LanguageServer {
+    watcher: FileWatcher,
+    notify: NotifyCallback,
+}
+
+impl LanguageServer {
+    pub fn new(notify: NotifyCallback) -> Self {
+        RESERVED_WORDS
+            .lock()
+            .unwrap()
+            .load_file("data\\compiler.ini");
+        Self {
+            watcher: FileWatcher::new(),
+            notify,
+        }
+    }
+
+    pub fn open(&mut self, file_name: &str, handle: EditorHandle) {
+        let dict = RESERVED_WORDS.lock().unwrap();
+        if let Some(tree) = scanner::document_tree(file_name, &dict) {
+            for file in tree {
+                self.start_watching(file, file_name, handle);
+            }
+        }
+
+        let notify = self.notify;
+        let main_file1 = String::from(file_name);
+
+        // needed to unlock the RESERVED_WORDS mutex for scan routine
+        drop(dict);
+
+        // spawn initial scan for the opened document
+        thread::spawn(move || LanguageServer::scan(&main_file1, &main_file1, notify));
+    }
+
+    fn start_watching(&mut self, file_name: String, main_file: &str, handle: EditorHandle) {
+        let mut files = WATCHED_FILES.lock().unwrap();
+        match files.get_mut(&file_name) {
+            Some(v) => {
+                v.insert(handle);
+            }
+            None => {
+                let mut set = HashSet::new();
+                set.insert(handle);
+                files.insert(file_name.clone(), set);
+            }
+        }
+        let notify = self.notify;
+        let file_name1 = file_name.clone();
+        let main_file1 = String::from(main_file);
+
+        self.watcher
+            .watch(file_name.as_str(), move |event| match event {
+                hotwatch::Event::Write(_) => LanguageServer::scan(&file_name1, &main_file1, notify),
+                _ => {
+                    // todo: check out other events, e.g. file delete or move
+                }
+            });
+    }
+
+    fn scan(file_name: &String, main_file: &String, notify: NotifyCallback) {
+        let files = WATCHED_FILES.lock().unwrap();
+        if let Some(handles) = files.get(file_name.as_str()) {
+            for &handle in handles {
+                // todo: parallel scan?
+                let mut table = SymbolTable::new();
+
+                let dict = RESERVED_WORDS.lock().unwrap();
+
+                if let Some(tree) = scanner::document_tree(main_file.as_str(), &dict) {
+                    for file in tree {
+                        if let Some(constants) = scanner::find_constants(file, &dict) {
+                            table.add(constants);
+                        }
+                    }
+                }
+
+                SYMBOL_TABLES.lock().unwrap().insert(handle, table);
+                notify(handle);
+            }
+        }
+    }
+
+    pub fn close(&mut self, file_name: &str, handle: EditorHandle) {
+        SYMBOL_TABLES.lock().unwrap().remove(&handle);
+        let mut f = WATCHED_FILES.lock().unwrap();
+        if let Some(v) = f.get_mut(file_name) {
+            v.remove(&handle);
+            if v.len() == 0 {
+                self.watcher.unwatch(file_name);
+            }
+        }
+    }
+
+    pub fn find(
+        &mut self,
+        symbol: &str,
+        handle: EditorHandle,
+        file_name: &str,
+    ) -> Option<SymbolInfo> {
+        let st = SYMBOL_TABLES.lock().unwrap();
+        let table = st.get(&handle)?;
+        let map = table.symbols.get(&symbol.to_ascii_lowercase())?;
+        Some(SymbolInfo {
+            line_number: if !map.file_name.eq(file_name) {
+                1
+            } else {
+                map.line_number
+            },
+            _type: map._type,
+        })
+    }
+}

--- a/src/language_service/symbol_table.rs
+++ b/src/language_service/symbol_table.rs
@@ -1,0 +1,18 @@
+use super::ffi::SymbolInfoMap;
+use std::collections::HashMap;
+
+pub struct SymbolTable {
+    pub symbols: HashMap<String, SymbolInfoMap>,
+}
+
+impl SymbolTable {
+    pub fn new() -> Self {
+        Self {
+            symbols: HashMap::new(),
+        }
+    }
+
+    pub fn add(&mut self, constants: Vec<(String, SymbolInfoMap)>) {
+        self.symbols.extend(constants);
+    }
+}

--- a/src/language_service/watcher.rs
+++ b/src/language_service/watcher.rs
@@ -16,7 +16,6 @@ impl FileWatcher {
         F: 'static + FnMut(Event) + Send,
     {
         if let Some(watcher) = &mut self.watcher {
-            log::debug!("Start watching file {}", file_name);
             match watcher.watch(file_name, handler) {
                 Ok(_) => log::debug!("Start watching file {}", file_name),
                 Err(_) => log::debug!("Can't start watching file {}", file_name),

--- a/src/language_service/watcher.rs
+++ b/src/language_service/watcher.rs
@@ -1,0 +1,66 @@
+use hotwatch::{Event, Hotwatch};
+use std::collections::HashMap;
+
+pub struct FileWatcher {
+    watcher: Option<Hotwatch>,
+    files: HashMap<String, i32>,
+}
+
+impl FileWatcher {
+    pub fn new() -> Self {
+        Self {
+            watcher: Hotwatch::new().ok(),
+            files: HashMap::new(),
+        }
+    }
+
+    pub fn watch<F>(&mut self, file_name: &str, handler: F)
+    where
+        F: 'static + FnMut(Event) + Send,
+    {
+        if let Some(watcher) = &mut self.watcher {
+            let key = String::from(file_name);
+            self.files
+                .raw_entry_mut()
+                .from_key(&key)
+                .and_modify(|_k, v| *v += 1)
+                .or_insert_with(|| {
+                    watcher.watch(file_name, handler);
+                    (key, 1)
+                });
+        };
+    }
+
+    pub fn unwatch(&mut self, file_name: &str) {
+        if let Some(watcher) = &mut self.watcher {
+            let key = String::from(file_name);
+
+            if let Some(v) = self.files.get_mut(&key) {
+                *v -= 1;
+                if *v == 0 {
+                    self.files.remove(&key);
+                    watcher.unwatch(file_name);
+                }
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test1() {
+        let mut f = FileWatcher::new();
+        f.watch("1.txt", |_| {});
+        f.watch("1.txt", |_| {});
+
+        assert_eq!(f.files.len(), 1);
+
+        f.unwatch("1.txt");
+        f.unwatch("1.txt");
+
+        assert_eq!(f.files.len(), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(never_type)]
 #![feature(bool_to_option)]
-#![feature(hash_raw_entry)]
 #![feature(hash_drain_filter)]
 #[macro_use]
 pub mod common_ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(never_type)]
 #![feature(bool_to_option)]
 #![feature(hash_raw_entry)]
+#![feature(hash_drain_filter)]
 #[macro_use]
 pub mod common_ffi;
 pub mod dictionary;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 #![feature(never_type)]
 #![feature(bool_to_option)]
+#![feature(hash_raw_entry)]
 #[macro_use]
 pub mod common_ffi;
 pub mod dictionary;
+pub mod language_service;
 pub mod math;
 pub mod namespaces;
 pub mod parser;


### PR DESCRIPTION
for https://github.com/sannybuilder/dev/issues/28


### Language service

This service spawns a new server on program startup. The server lives during all program lifetime. The api allows to connect multiple client instances responsible for different documents. 

Each document includes the main file (opened in Sanny) and possibly many others included in the main file explicitly via the `{$INCLUDE}` directive or implicitly (`constants.txt` from the edit mode config). They constitute the document tree model.

Server watches for file changes for each file in the tree and sends a message back to Sanny. Currently it triggers highlighting change and document status update (Disabled, Ready, Scanning).