### PR TITLE
enum parser fails if field name contains end word

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,3 +3,6 @@ target = "i686-pc-windows-msvc"
 
 [alias]
 b = "build --out-dir=..\\..\\exe\\lib -Z unstable-options"
+
+[target.i686-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static", "-Zunstable-options"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,26 +2,25 @@ name: ci
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1.0.6
-      with:
-        toolchain: nightly
-        target: i686-pc-windows-msvc
-        override: true
-    - name: Build
-      run: cargo build --release --verbose
-    - name: Run tests
-      run: cargo test --release --verbose
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: i686-pc-windows-msvc
+          override: true
+      - name: Build
+        run: cargo build --release --verbose
+      - name: Run tests
+        run: cargo test --release --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,13 +179,13 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]
@@ -358,6 +358,7 @@ version = "0.2.2"
 dependencies = [
  "hotwatch",
  "lazy_static",
+ "lexical-core",
  "libc",
  "log",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "sanny_builder_core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hotwatch",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sanny_builder_core"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Seemann <mail@sannybuilder.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ hotwatch = "0.4.5"
 lazy_static = "1.4.0"
 log = { version = "0.4.11", features = ["release_max_level_off"] }
 simplelog = "0.9.0"
+lexical-core = "0.7.6"


### PR DESCRIPTION
- [x] fix error in enums if field name has `end` in it https://github.com/sannybuilder/dev/issues/139
- [x] statically link VC runtime to avoid need in VC Redist x86
- [x] fix CI build issue with lexical-core package